### PR TITLE
Fix homepage package name and docs link

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -229,7 +229,7 @@
                             <figure class="highlight highlight-dark text-left my-4">
                                     <code>
                                         <span class="c1"># Install compodoc with npm</span>
-                                        <span class="c2">$ npm install -g compodoc</span>
+                                        <span class="c2">$ npm install -g @compodoc/compodoc</span>
                                         <span class="c1"># Run compodoc in your project and serve it</span>
                                         <span class="c2">$ compodoc src -s</span>
                                     </code>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -235,7 +235,7 @@
                                     </code>
                             </figure>
                             <p>
-                                <h3>Read the <a href="https://github.com/compodoc/compodoc#table-of-contents" target="_blank">documentation</a> for others scenarios.</h3>
+                                <h3>Read the <a href="https://compodoc.github.io/website/guides/getting-started.html" target="_blank">documentation</a> for others scenarios.</h3>
                             </p>
 	                    </div>
 	                </div>


### PR DESCRIPTION
The package name on the homepage is `compodoc` instead of `@compodoc/compodoc` (it's just missing the scope).

The documentation link goes to the GitHub `README`, which tells the user that the docs moved to the website they just came from. The link should just go directly to the "Guides" section of the website instead.