### PR TITLE
Update tips-and-tricks.html

### DIFF
--- a/docs/tips-and-tricks.html
+++ b/docs/tips-and-tricks.html
@@ -5,6 +5,8 @@
 @import &quot;./bootstrap-card.css&quot;;
 @import &quot;./font-awesome.min.css&quot;;
 @import &quot;./compodoc.css&quot;;
+@import &quot;./prism.css&quot;;
+@import &quot;./tablesort.css&quot;;
 </code></pre><p>Compodoc use <a href="http://getbootstrap.com/">bootstrap</a> 3.3.7. You can customize Compodoc easily.</p>
 <p><a href="http://bootswatch.com/">bootswatch.com</a> can be a good starting point. If you want to override the default theme, just provide a bootstrap.min.css file, and it will override the default one.</p>
 <pre><code>└── your_theme_styles/


### PR DESCRIPTION
Overriding the default theme with just a style.css and a bootstrap.min.css breaks syntax highlighting without the prism.css. I assume tablesort.css is also needed.