### PR TITLE
Fix contributing broken link

### DIFF
--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -14,7 +14,7 @@ Compodoc is an open source effort from [Vincent Ogloblinsky](http://www.vincento
 
 Developers can contribute and fork the repo on [GitHub](https://github.com/compodoc/compodoc).
 
-Don't forget to read the [Contributing guide](https://github.com/compodoc/compodoc/blob/master/.github/CONTRIBUTING.md).
+Don't forget to read the [Contributing guide](https://github.com/compodoc/compodoc/blob/master/CONTRIBUTING.md).
 
 # Ready ? Go !
 


### PR DESCRIPTION
Broken link was here:
https://compodoc.github.io/website/guides/getting-started.html

Don't forget to read the **Contributing guide**.