### PR TITLE
fix: update npm link on front page

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -146,7 +146,7 @@
                     <a href="https://travis-ci.org/compodoc/compodoc"><img src="https://travis-ci.org/compodoc/compodoc.svg?branch=develop" alt="Build Status"></a>
                     <a href="https://ci.appveyor.com/project/vogloblinsky/compodoc/branch/develop"><img src="https://ci.appveyor.com/api/projects/status/0wkundlfn3vs6r3m/branch/develop?svg=true" alt="Build Status"></a>
                     <a href="https://codecov.io/gh/compodoc/compodoc"><img src="https://codecov.io/gh/compodoc/compodoc/branch/develop/graph/badge.svg" alt="Codecov"></a>
-                    <a href="https://www.npmjs.com/package/compodoc"><img src="https://badge.fury.io/js/%40compodoc%2Fcompodoc.svg" alt="npm badge"></a>
+                    <a href="https://www.npmjs.com/package/@compodoc/compodoc"><img src="https://badge.fury.io/js/%40compodoc%2Fcompodoc.svg" alt="npm badge"></a>
                     <a class="github-button" href="https://github.com/compodoc/compodoc" data-count-href="/compodoc/compodoc/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star compodoc/compodoc on GitHub">Star</a>
               </div>
             </div>


### PR DESCRIPTION
The npm badge on the front page of https://compodoc.app/ currently links to the page for the deprecated compodoc package (https://www.npmjs.com/package/compodoc)