### PR TITLE
point changelog link to default branch (develop) instead of master

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -52,7 +52,7 @@
 						<ul class="nav navbar-nav navbar-right">
                             <li><a href="./guides/getting-started.html">Getting started</a></li>
                             <li><a href="./guides/features.html">Features</a></li>
-                            <li><a class="social-changelog" href="https://github.com/compodoc/compodoc/blob/master/CHANGELOG.md" target="_blank"><span class="typcn typcn-document-text"></span>Changelog</a></li>
+                            <li><a class="social-changelog" href="https://github.com/compodoc/compodoc/blob/develop/CHANGELOG.md" target="_blank"><span class="typcn typcn-document-text"></span>Changelog</a></li>
                             <li><a class="social-github" href="https://github.com/compodoc/compodoc" target="_blank"><span class="typcn typcn-social-github"></span>GitHub</a></li>
 						</ul>
 					</div>


### PR DESCRIPTION
I noticed that the "changelog" link on the website sends you to the CHANGELOG.md file on the master branch instead of the up to date version on the develop branch.  This pull request is link to the up to date changelog file.